### PR TITLE
Feat/selection page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -13,7 +13,7 @@ class App extends Component {
     }
   }
 
-  filterBooks(event) {
+  filterBooks = (event) => {
     if (event.target.value === "misc") {
       const filteredBooks = this.state.lists.filter(category => {
         return !category.display_name.includes("Fiction") && !category.display_name.includes("Nonfiction") && !category.display_name.includes("Young Adult") && !category.display_name.includes("Children")

--- a/src/App.js
+++ b/src/App.js
@@ -8,7 +8,24 @@ class App extends Component {
   constructor() {
     super();
     this.state = {
-      lists: []
+      lists: [],
+      filteredLists: []
+    }
+  }
+
+  filterBooks(event) {
+    if (event.target.value === "misc") {
+      const filteredBooks = this.state.lists.filter(category => {
+        return !category.display_name.includes("Fiction") && !category.display_name.includes("Nonfiction") && !category.display_name.includes("Young Adult") && !category.display_name.includes("Children")
+      })
+      this.setState({ filteredLists: filteredBooks })
+    } else if (event.target.value) {
+      const filteredBooks = this.state.lists.filter(category => {
+        return category.display_name.includes(event.target.value)
+      })
+      this.setState({ filteredLists: filteredBooks })
+    } else if (event.target.value === "all") {
+      this.setState({ filteredLists: [] })
     }
   }
 
@@ -21,7 +38,7 @@ class App extends Component {
     return (
       <>
         <Header />
-        <Selection lists={this.state.lists}/>
+        <Selection lists={this.state.lists} filteredLists={this.state.filteredLists} filterBooks={this.filterBooks} />
       </>
     )
   }

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,18 @@
 import React, { Component } from 'react';
+import { Route } from 'react-router-dom';
 import './App.css';
 import getData from './util';
-import Selection from './Views/Selection/Selection';
 import Header from './Components/Header/Header';
+import Selection from './Views/Selection/Selection';
+import Preview from './Views/Preview/Preview';
 
 class App extends Component {
   constructor() {
     super();
     this.state = {
       lists: [],
-      filteredLists: []
+      filteredLists: [],
+      category: ""
     }
   }
 
@@ -29,6 +32,10 @@ class App extends Component {
     }
   }
 
+  chooseCategory = (category) => {
+    this.setState({ category: category })
+  }
+
   componentDidMount = () => {
     return getData("https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=obrhAVJmNNtUdhs3RSbGr7Shq6cwxtyH")
       .then(data => this.setState({ lists: data.results }))
@@ -38,7 +45,8 @@ class App extends Component {
     return (
       <>
         <Header />
-        <Selection lists={this.state.lists} filteredLists={this.state.filteredLists} filterBooks={this.filterBooks} />
+        <Route exact path="/" render={() => <Selection lists={this.state.lists} filteredLists={this.state.filteredLists} filterBooks={this.filterBooks} chooseCategory={this.chooseCategory} />} />
+        <Route path="/preview/:category" render={() => <Preview category={this.state.category} />} />
       </>
     )
   }

--- a/src/App.js
+++ b/src/App.js
@@ -1,15 +1,30 @@
-import React from 'react';
+import React, { Component } from 'react';
 import './App.css';
+import getData from './util';
 import Selection from './Views/Selection/Selection';
 import Header from './Components/Header/Header';
 
-const App = () => {
-  return (
-    <>
-      <Header />
-      <Selection />
-    </>
-  )
+class App extends Component {
+  constructor() {
+    super();
+    this.state = {
+      lists: []
+    }
+  }
+
+  componentDidMount = () => {
+    return getData("https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=obrhAVJmNNtUdhs3RSbGr7Shq6cwxtyH")
+      .then(data => this.setState({ lists: data.results }))
+  }
+
+  render() {
+    return (
+      <>
+        <Header />
+        <Selection lists={this.state.lists}/>
+      </>
+    )
+  }
 }
 
 export default App;

--- a/src/Components/BookPreview/BookPreview.css
+++ b/src/Components/BookPreview/BookPreview.css
@@ -1,0 +1,21 @@
+.allBookPreviews {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+}
+
+.categoryName {
+  margin: 0;
+  margin-top: 2%;
+}
+
+.bookPreview {
+  font-size: larger;
+  width: 90%;
+  padding: 1%;
+  border: 3px solid brown;
+  margin-top: 2%;
+  margin-bottom: 2%;
+  text-align: center;
+}

--- a/src/Components/BookPreview/BookPreview.css
+++ b/src/Components/BookPreview/BookPreview.css
@@ -5,14 +5,35 @@
   align-items: center;
 }
 
-.categoryName {
-  margin: 0;
+.previewLabels {
+  width: 90%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
   margin-top: 2%;
+  margin-left: 5%;
+  margin-right: 5%;
+}
+
+.previewLabels h2 {
+  margin: 0;
+}
+
+.bookPreviewRank {
+  width: 95%;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+}
+
+.bookRank {
+  border: 3px solid rebeccapurple;
+  text-align: center;
 }
 
 .bookPreview {
   font-size: larger;
-  width: 90%;
+  width: 80%;
   padding: 1%;
   border: 3px solid brown;
   margin-top: 2%;

--- a/src/Components/BookPreview/BookPreview.js
+++ b/src/Components/BookPreview/BookPreview.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import './BookPreview.css';
+
+const BookPreview = ({ bestSellers }) => {
+
+  const bookPreviews = bestSellers.map(book => {
+    
+  })
+
+  return (
+    <h1>Ok</h1>
+  )
+}
+
+export default BookPreview;

--- a/src/Components/BookPreview/BookPreview.js
+++ b/src/Components/BookPreview/BookPreview.js
@@ -1,31 +1,40 @@
 import React from 'react';
 import './BookPreview.css';
+import { Link } from 'react-router-dom';
 
 const BookPreview = ({ bestSellers }) => {
 
   if (bestSellers.length) {
-    const categoryName = bestSellers[0].display_name
-    
+    const categoryName = bestSellers[0].display_name;
     const bookPreviews = bestSellers.map(book => {
-      return <article className="bookPreview">
-             <h3>{book.book_details[0].title}</h3>
-             <p>by {book.book_details[0].author}</p>
-             <p>{book.book_details[0].description}</p>
-             <p>Weeks on New York Times Bestseller List: {book.weeks_on_list}</p>
-             <p>Rank Last Week: {book.rank_last_week}</p>
-           </article>
-    })
+      return  <section className="bookPreviewRank">
+                <aside className="bookRank">
+                  <p>#{book.rank}</p>
+                </aside>
+                <article className="bookPreview">
+                  <h3>{book.book_details[0].title}</h3>
+                  <p>by {book.book_details[0].author}</p>
+                  <p>{book.book_details[0].description}</p>
+                  <p>Weeks on New York Times Bestseller List: {book.weeks_on_list}</p>
+                  <p>Rank Last Week: {book.rank_last_week}</p>
+                </article>
+              </section>
+    });
   
     return (
-      <section className="allBookPreviews">
-        <h2 className="categoryName">{categoryName}</h2>
+      <main className="allBookPreviews">
+        <div className="previewLabels">
+          <h2>Rank</h2>
+          <h2 className="categoryName">{categoryName}</h2>
+          <Link to="/">Back to Home</Link>
+        </div>
         {bookPreviews}
-      </section>
-    )
+      </main>
+    );
   } else {
     return (
       <h2>Loading...</h2>
-    )
+    );
   }
 }
 

--- a/src/Components/BookPreview/BookPreview.js
+++ b/src/Components/BookPreview/BookPreview.js
@@ -3,13 +3,30 @@ import './BookPreview.css';
 
 const BookPreview = ({ bestSellers }) => {
 
-  const bookPreviews = bestSellers.map(book => {
+  if (bestSellers.length) {
+    const categoryName = bestSellers[0].display_name
     
-  })
-
-  return (
-    <h1>Ok</h1>
-  )
+    const bookPreviews = bestSellers.map(book => {
+      return <article className="bookPreview">
+             <h3>{book.book_details[0].title}</h3>
+             <p>by {book.book_details[0].author}</p>
+             <p>{book.book_details[0].description}</p>
+             <p>Weeks on New York Times Bestseller List: {book.weeks_on_list}</p>
+             <p>Rank Last Week: {book.rank_last_week}</p>
+           </article>
+    })
+  
+    return (
+      <section className="allBookPreviews">
+        <h2 className="categoryName">{categoryName}</h2>
+        {bookPreviews}
+      </section>
+    )
+  } else {
+    return (
+      <h2>Loading...</h2>
+    )
+  }
 }
 
 export default BookPreview;

--- a/src/Components/Filter/Filter.css
+++ b/src/Components/Filter/Filter.css
@@ -1,0 +1,14 @@
+.listFilters {
+  margin: 2%;
+  width: 90%;
+  height: 3em;
+  border: 3px solid green;
+  text-align: center;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.listFilters label {
+  font-size: larger;
+}

--- a/src/Components/Filter/Filter.js
+++ b/src/Components/Filter/Filter.js
@@ -6,30 +6,60 @@ const Filter = ({ filterBooks }) => {
   return (
     <form className="listFilters">
       <div>
-          <label htmlFor="all">All</label>
-          <input name="filter" value="all" type="radio" onClick={(event) => this.filterBooks(event)} />
-        </div>
-        <div>
-          <label htmlFor="fiction">Fiction</label>
-          <input name="filter" value="Fiction" type="radio" onClick={(event) => this.filterBooks(event)} />
-        </div>
-        <div>
-          <label htmlFor="nonFiction">Non-Fiction</label>
-          <input name="filter" value="Nonfiction" type="radio" onClick={(event) => this.filterBooks(event)} />
-        </div>
-        <div>
-          <label htmlFor="misc">Miscellaneous</label>
-          <input name="filter" value="misc" type="radio" onClick={(event) => this.filterBooks(event)} />
-        </div>
-        <div>
-          <label htmlFor="youngAdult">Young Adult</label>
-          <input name="filter" value="Young Adult" type="radio" onClick={(event) => this.filterBooks(event)} />
-        </div>
-        <div>
-          <label htmlFor="kids">Kids</label>
-          <input name="filter" value="Children" type="radio" onClick={(event) => this.filterBooks(event)} />
-        </div>
-      </form>
+        <label>All
+          <input 
+            name="filter" 
+            value="all" 
+            type="radio" 
+            onClick={(event) => filterBooks(event)} />
+        </label>
+      </div>
+      <div>
+        <label>Fiction
+          <input 
+            name="filter" 
+            value="Fiction" 
+            type="radio" 
+            onClick={(event) => filterBooks(event)} />
+        </label>    
+      </div>
+      <div>
+        <label>Non-Fiction
+          <input 
+            name="filter" 
+            value="Nonfiction" 
+            type="radio" 
+            onClick={(event) => filterBooks(event)} />
+        </label> 
+      </div>
+      <div>
+        <label>Miscellaneous
+          <input 
+            name="filter" 
+            value="misc" 
+            type="radio" 
+            onClick={(event) => filterBooks(event)} />
+        </label>
+      </div>
+      <div>
+        <label>Young Adult
+          <input 
+            name="filter" 
+            value="Young Adult" 
+            type="radio" 
+            onClick={(event) => filterBooks(event)} />
+        </label>
+      </div>
+      <div>
+        <label>Kids
+          <input 
+          name="filter" 
+          value="Children" 
+          type="radio" 
+          onClick={(event) => filterBooks(event)} />
+        </label>
+      </div>
+    </form>
   )
 }
 

--- a/src/Components/Filter/Filter.js
+++ b/src/Components/Filter/Filter.js
@@ -1,0 +1,13 @@
+import React, { Component } from 'react';
+import './Filter.css';
+
+class Filter extends Component {
+  constructor() {
+    super()
+    this.state = {
+      filteredLists: []
+    }
+  }
+}
+
+export default Filter;

--- a/src/Components/Filter/Filter.js
+++ b/src/Components/Filter/Filter.js
@@ -1,13 +1,36 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './Filter.css';
 
-class Filter extends Component {
-  constructor() {
-    super()
-    this.state = {
-      filteredLists: []
-    }
-  }
+const Filter = ({ filterBooks }) => {
+  
+  return (
+    <form className="listFilters">
+      <div>
+          <label htmlFor="all">All</label>
+          <input name="filter" value="all" type="radio" onClick={(event) => this.filterBooks(event)} />
+        </div>
+        <div>
+          <label htmlFor="fiction">Fiction</label>
+          <input name="filter" value="Fiction" type="radio" onClick={(event) => this.filterBooks(event)} />
+        </div>
+        <div>
+          <label htmlFor="nonFiction">Non-Fiction</label>
+          <input name="filter" value="Nonfiction" type="radio" onClick={(event) => this.filterBooks(event)} />
+        </div>
+        <div>
+          <label htmlFor="misc">Miscellaneous</label>
+          <input name="filter" value="misc" type="radio" onClick={(event) => this.filterBooks(event)} />
+        </div>
+        <div>
+          <label htmlFor="youngAdult">Young Adult</label>
+          <input name="filter" value="Young Adult" type="radio" onClick={(event) => this.filterBooks(event)} />
+        </div>
+        <div>
+          <label htmlFor="kids">Kids</label>
+          <input name="filter" value="Children" type="radio" onClick={(event) => this.filterBooks(event)} />
+        </div>
+      </form>
+  )
 }
 
 export default Filter;

--- a/src/Components/ListBox/ListBox.css
+++ b/src/Components/ListBox/ListBox.css
@@ -5,8 +5,6 @@
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
-  /* margin-top: 5%; */
-  /* margin-bottom: 5%; */
 }
 
 .category {

--- a/src/Components/ListBox/ListBox.css
+++ b/src/Components/ListBox/ListBox.css
@@ -11,7 +11,7 @@
 
 .category {
   width: 16%;
-  height: 14em;
+  height: 17em;
   border: 3px solid blue;
   border-radius: 60px 10px 0px 15px/15px 30px 45px 30px;
   background-color: azure;
@@ -23,4 +23,9 @@
   display: flex;
   justify-content: center;
   align-items: center;
+}
+
+.stepOne {
+  font-size: xx-large;
+  margin: 1%;
 }

--- a/src/Components/ListBox/ListBox.css
+++ b/src/Components/ListBox/ListBox.css
@@ -5,8 +5,8 @@
   justify-content: center;
   align-items: center;
   flex-wrap: wrap;
-  margin-top: 5%;
-  margin-bottom: 5%;
+  /* margin-top: 5%; */
+  /* margin-bottom: 5%; */
 }
 
 .category {

--- a/src/Components/ListBox/ListBox.js
+++ b/src/Components/ListBox/ListBox.js
@@ -2,11 +2,21 @@ import React from 'react'
 import { Link } from 'react-router-dom';
 import './ListBox.css';
 
-const ListBox = ({ list }) => {
+const ListBox = ({ lists, filteredLists }) => {
 
-  const categories = list.map(category => {
-    return <Link className='category'>{category.display_name}</Link>
+  let categories;
+
+  const makeLinks = (listType) => listType.map(category => {
+    return <Link className='category' key={category}>{category.display_name}</Link>
   })
+
+  if (filteredLists.length) {
+    categories = makeLinks(filteredLists)
+  } else if (lists) {
+    categories = makeLinks(lists)
+  }
+
+  console.log(lists, filteredLists)
 
   return (
     <section className='listBox'>

--- a/src/Components/ListBox/ListBox.js
+++ b/src/Components/ListBox/ListBox.js
@@ -2,12 +2,18 @@ import React from 'react'
 import { Link } from 'react-router-dom';
 import './ListBox.css';
 
-const ListBox = ({ lists, filteredLists }) => {
+const ListBox = ({ lists, filteredLists, chooseCategory }) => {
 
   let categories;
 
   const makeLinks = (listType) => listType.map(category => {
-    return <Link className='category' key={category}>{category.display_name}</Link>
+    return <Link 
+        to={`preview/${category.list_name_encoded}`} 
+        className='category' 
+        key={category.list_name_encoded}
+        onClick={() => chooseCategory(category.list_name_encoded)}>
+          {category.display_name}
+      </Link>
   })
 
   if (filteredLists.length) {
@@ -15,8 +21,6 @@ const ListBox = ({ lists, filteredLists }) => {
   } else if (lists) {
     categories = makeLinks(lists)
   }
-
-  console.log(lists, filteredLists)
 
   return (
     <section className='listBox'>

--- a/src/Views/Preview/Preview.js
+++ b/src/Views/Preview/Preview.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react';
+import BookPreview from '../../Components/BookPreview/BookPreview';
 import getData from '../../util';
 import './Preview.css';
 
@@ -17,7 +18,7 @@ class Preview extends Component {
 
   render() {
     return (
-      <h1>Let's do ittttttt.</h1>
+      <BookPreview bestSellers={this.state.bestSellers} />
     )
   }
 }

--- a/src/Views/Preview/Preview.js
+++ b/src/Views/Preview/Preview.js
@@ -1,0 +1,25 @@
+import React, { Component } from 'react';
+import getData from '../../util';
+import './Preview.css';
+
+class Preview extends Component {
+  constructor() {
+    super() 
+    this.state = {
+      bestSellers: []
+    }
+  }
+
+  componentDidMount() {
+    getData(`https://api.nytimes.com/svc/books/v3/lists.json?list=${this.props.category}&api-key=obrhAVJmNNtUdhs3RSbGr7Shq6cwxtyH`)
+      .then(data => this.setState({ bestSellers: data.results.splice(0, 10) }))
+  }
+
+  render() {
+    return (
+      <h1>Let's do ittttttt.</h1>
+    )
+  }
+}
+
+export default Preview;

--- a/src/Views/Selection/Selection.css
+++ b/src/Views/Selection/Selection.css
@@ -11,4 +11,12 @@
   margin: 2%;
   width: 90%;
   border: 3px solid green;
+  text-align: center;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+}
+
+.listFilters label {
+  font-size: larger;
 }

--- a/src/Views/Selection/Selection.css
+++ b/src/Views/Selection/Selection.css
@@ -6,17 +6,3 @@
   align-items: center;
   padding: 3%;
 }
-
-.listFilters {
-  margin: 2%;
-  width: 90%;
-  border: 3px solid green;
-  text-align: center;
-  display: flex;
-  justify-content: space-evenly;
-  align-items: center;
-}
-
-.listFilters label {
-  font-size: larger;
-}

--- a/src/Views/Selection/Selection.css
+++ b/src/Views/Selection/Selection.css
@@ -1,5 +1,14 @@
 .selection {
   height: 100%;
   display: flex;
-  justify-content: center;
+  flex-direction: column;
+  justify-content: space-around;
+  align-items: center;
+  padding: 3%;
+}
+
+.listFilters {
+  margin: 2%;
+  width: 90%;
+  border: 3px solid green;
 }

--- a/src/Views/Selection/Selection.js
+++ b/src/Views/Selection/Selection.js
@@ -3,13 +3,13 @@ import './Selection.css';
 import ListBox from '../../Components/ListBox/ListBox';
 import Filter from '../../Components/Filter/Filter';
 
-const Selection = ({ lists, filteredLists, filterBooks }) => {
+const Selection = ({ lists, filteredLists, filterBooks, chooseCategory }) => {
 
   return (
     <main className="selection">
-      <h2 className="stepOne">Step 1: Pick a Category</h2>
+      <h2 className="stepOne">Step 1: Browse Categories</h2>
       <Filter filterBooks={filterBooks}/>
-      <ListBox lists={lists} filteredLists={filteredLists}/>
+      <ListBox lists={lists} filteredLists={filteredLists} chooseCategory={chooseCategory} />
     </main>
   )
 }

--- a/src/Views/Selection/Selection.js
+++ b/src/Views/Selection/Selection.js
@@ -9,7 +9,7 @@ const Selection = ({ lists, filteredLists, filterBooks }) => {
     <main className="selection">
       <h2 className="stepOne">Step 1: Pick a Category</h2>
       <Filter filterBooks={filterBooks}/>
-      <ListBox lists={this.state.lists} filteredLists={this.state.filteredLists}/>
+      <ListBox lists={lists} filteredLists={filteredLists}/>
     </main>
   )
 }

--- a/src/Views/Selection/Selection.js
+++ b/src/Views/Selection/Selection.js
@@ -1,72 +1,17 @@
-import React, { Component } from 'react';
+import React from 'react';
 import './Selection.css';
-import getData from '../../util';
 import ListBox from '../../Components/ListBox/ListBox';
+import Filter from '../../Components/Filter/Filter';
 
-class Selection extends Component {
-  constructor() {
-    super();
-    this.state = {
-      lists: [],
-      filteredLists: [],
-    }
-  }
+const Selection = ({ lists, filteredLists, filterBooks }) => {
 
-  filterBooks(event) {
-    if (event.target.value === "misc") {
-      const filteredBooks = this.state.lists.filter(category => {
-        return !category.display_name.includes("Fiction") && !category.display_name.includes("Nonfiction") && !category.display_name.includes("Young Adult") && !category.display_name.includes("Children")
-      })
-      this.setState({ filteredLists: filteredBooks })
-    } else if (event.target.value) {
-      const filteredBooks = this.state.lists.filter(category => {
-        return category.display_name.includes(event.target.value)
-      })
-      this.setState({ filteredLists: filteredBooks })
-    } else if (event.target.value === "all") {
-      this.setState({ filteredLists: [] })
-    }
-  }
-
-  componentDidMount = () => {
-    return getData("https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=obrhAVJmNNtUdhs3RSbGr7Shq6cwxtyH")
-      .then(data => this.setState({ lists: data.results }))
-  }
-
-  render() {
-    return (
-      <main className="selection">
-        <h2 className="stepOne">Step 1: Pick a Category</h2>
-        <form className="listFilters">
-        <div>
-            <label htmlFor="all">All</label>
-            <input name="filter" value="all" type="radio" onClick={(event) => this.filterBooks(event)} />
-          </div>
-          <div>
-            <label htmlFor="fiction">Fiction</label>
-            <input name="filter" value="Fiction" type="radio" onClick={(event) => this.filterBooks(event)} />
-          </div>
-          <div>
-            <label htmlFor="nonFiction">Non-Fiction</label>
-            <input name="filter" value="Nonfiction" type="radio" onClick={(event) => this.filterBooks(event)} />
-          </div>
-          <div>
-            <label htmlFor="misc">Miscellaneous</label>
-            <input name="filter" value="misc" type="radio" onClick={(event) => this.filterBooks(event)} />
-          </div>
-          <div>
-            <label htmlFor="youngAdult">Young Adult</label>
-            <input name="filter" value="Young Adult" type="radio" onClick={(event) => this.filterBooks(event)} />
-          </div>
-          <div>
-            <label htmlFor="kids">Kids</label>
-            <input name="filter" value="Children" type="radio" onClick={(event) => this.filterBooks(event)} />
-          </div>
-        </form>
-        <ListBox lists={this.state.lists} filteredLists={this.state.filteredLists}/>
-      </main>
-    )
-  }
+  return (
+    <main className="selection">
+      <h2 className="stepOne">Step 1: Pick a Category</h2>
+      <Filter filterBooks={filterBooks}/>
+      <ListBox lists={this.state.lists} filteredLists={this.state.filteredLists}/>
+    </main>
+  )
 }
 
 export default Selection

--- a/src/Views/Selection/Selection.js
+++ b/src/Views/Selection/Selection.js
@@ -19,15 +19,24 @@ class Selection extends Component {
   render() {
     return (
       <main className="selection">
+        <h2 className="stepOne">Step 1: Pick a Category</h2>
         <form className="listFilters">
-          <label for="kids">Kids</label>
-          <input name="kids" type="checkbox" />
-          <label for="youngAdult">Young Adult</label>
-          <input name="youngAdult" type="checkbox" />
-          <label for="fiction">Fiction</label>
-          <input name="fiction" type="checkbox" />
-          <label for="nonFiction">Non-Fiction</label>
-          <input name="nonFiction" type="checkbox" />
+          <div>
+            <label for="kids">Kids</label>
+            <input name="kids" type="checkbox" />
+          </div>
+          <div>
+            <label for="youngAdult">Young Adult</label>
+            <input name="youngAdult" type="checkbox" />
+          </div>
+          <div>
+            <label for="fiction">Fiction</label>
+            <input name="fiction" type="checkbox" />
+          </div>
+          <div>
+            <label for="nonFiction">Non-Fiction</label>
+            <input name="nonFiction" type="checkbox" />
+          </div>
         </form>
         <ListBox list={this.state.list}/>
       </main>

--- a/src/Views/Selection/Selection.js
+++ b/src/Views/Selection/Selection.js
@@ -7,20 +7,25 @@ class Selection extends Component {
   constructor() {
     super();
     this.state = {
-      list: [],
+      lists: [],
+      filteredLists: [],
     }
   }
 
   filterBooks(event) {
-    const filteredBooks = this.state.list.filter(category => {
-      return category.display_name.includes(event.target.value)
-    })
-    this.setState({ list: filteredBooks })
+    if (event.target.value === "all") {
+      this.setState({ filteredLists: [] })
+    } else {
+      const filteredBooks = this.state.lists.filter(category => {
+        return category.display_name.includes(event.target.value)
+      })
+      this.setState({ filteredLists: filteredBooks })
+    }
   }
 
   componentDidMount = () => {
     return getData("https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=obrhAVJmNNtUdhs3RSbGr7Shq6cwxtyH")
-      .then(data => this.setState({ list: data.results }))
+      .then(data => this.setState({ lists: data.results }))
   }
 
   render() {
@@ -30,26 +35,26 @@ class Selection extends Component {
         <form className="listFilters">
           <div>
             <label htmlFor="all">All</label>
-            <input name="all" value="*" type="radio" onClick={(event) => this.filterBooks(event)} />
+            <input name="filter" value="all" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
           <div>
             <label htmlFor="kids">Kids</label>
-            <input name="kids" value="Children" type="radio" onClick={(event) => this.filterBooks(event)} />
+            <input name="filter" value="Children" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
           <div>
             <label htmlFor="youngAdult">Young Adult</label>
-            <input name="youngAdult" value="Young Adult" type="radio" onClick={(event) => this.filterBooks(event)} />
+            <input name="filter" value="Young Adult" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
           <div>
             <label htmlFor="fiction">Fiction</label>
-            <input name="fiction" value="Fiction" type="radio" onClick={(event) => this.filterBooks(event)} />
+            <input name="filter" value="Fiction" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
           <div>
             <label htmlFor="nonFiction">Non-Fiction</label>
-            <input name="nonFiction" value="Nonfiction" type="radio" onClick={(event) => this.filterBooks(event)} />
+            <input name="filter" value="Nonfiction" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
         </form>
-        <ListBox list={this.state.list}/>
+        <ListBox lists={this.state.lists} filteredLists={this.state.filteredLists}/>
       </main>
     )
   }

--- a/src/Views/Selection/Selection.js
+++ b/src/Views/Selection/Selection.js
@@ -11,6 +11,13 @@ class Selection extends Component {
     }
   }
 
+  filterBooks(event) {
+    const filteredBooks = this.state.list.filter(category => {
+      return category.display_name.includes(event.target.value)
+    })
+    this.setState({ list: filteredBooks })
+  }
+
   componentDidMount = () => {
     return getData("https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=obrhAVJmNNtUdhs3RSbGr7Shq6cwxtyH")
       .then(data => this.setState({ list: data.results }))
@@ -22,20 +29,24 @@ class Selection extends Component {
         <h2 className="stepOne">Step 1: Pick a Category</h2>
         <form className="listFilters">
           <div>
-            <label for="kids">Kids</label>
-            <input name="kids" type="checkbox" />
+            <label htmlFor="all">All</label>
+            <input name="all" value="*" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
           <div>
-            <label for="youngAdult">Young Adult</label>
-            <input name="youngAdult" type="checkbox" />
+            <label htmlFor="kids">Kids</label>
+            <input name="kids" value="Children" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
           <div>
-            <label for="fiction">Fiction</label>
-            <input name="fiction" type="checkbox" />
+            <label htmlFor="youngAdult">Young Adult</label>
+            <input name="youngAdult" value="Young Adult" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
           <div>
-            <label for="nonFiction">Non-Fiction</label>
-            <input name="nonFiction" type="checkbox" />
+            <label htmlFor="fiction">Fiction</label>
+            <input name="fiction" value="Fiction" type="radio" onClick={(event) => this.filterBooks(event)} />
+          </div>
+          <div>
+            <label htmlFor="nonFiction">Non-Fiction</label>
+            <input name="nonFiction" value="Nonfiction" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
         </form>
         <ListBox list={this.state.list}/>

--- a/src/Views/Selection/Selection.js
+++ b/src/Views/Selection/Selection.js
@@ -13,13 +13,18 @@ class Selection extends Component {
   }
 
   filterBooks(event) {
-    if (event.target.value === "all") {
-      this.setState({ filteredLists: [] })
-    } else {
+    if (event.target.value === "misc") {
+      const filteredBooks = this.state.lists.filter(category => {
+        return !category.display_name.includes("Fiction") && !category.display_name.includes("Nonfiction") && !category.display_name.includes("Young Adult") && !category.display_name.includes("Children")
+      })
+      this.setState({ filteredLists: filteredBooks })
+    } else if (event.target.value) {
       const filteredBooks = this.state.lists.filter(category => {
         return category.display_name.includes(event.target.value)
       })
       this.setState({ filteredLists: filteredBooks })
+    } else if (event.target.value === "all") {
+      this.setState({ filteredLists: [] })
     }
   }
 
@@ -33,17 +38,9 @@ class Selection extends Component {
       <main className="selection">
         <h2 className="stepOne">Step 1: Pick a Category</h2>
         <form className="listFilters">
-          <div>
+        <div>
             <label htmlFor="all">All</label>
             <input name="filter" value="all" type="radio" onClick={(event) => this.filterBooks(event)} />
-          </div>
-          <div>
-            <label htmlFor="kids">Kids</label>
-            <input name="filter" value="Children" type="radio" onClick={(event) => this.filterBooks(event)} />
-          </div>
-          <div>
-            <label htmlFor="youngAdult">Young Adult</label>
-            <input name="filter" value="Young Adult" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
           <div>
             <label htmlFor="fiction">Fiction</label>
@@ -52,6 +49,18 @@ class Selection extends Component {
           <div>
             <label htmlFor="nonFiction">Non-Fiction</label>
             <input name="filter" value="Nonfiction" type="radio" onClick={(event) => this.filterBooks(event)} />
+          </div>
+          <div>
+            <label htmlFor="misc">Miscellaneous</label>
+            <input name="filter" value="misc" type="radio" onClick={(event) => this.filterBooks(event)} />
+          </div>
+          <div>
+            <label htmlFor="youngAdult">Young Adult</label>
+            <input name="filter" value="Young Adult" type="radio" onClick={(event) => this.filterBooks(event)} />
+          </div>
+          <div>
+            <label htmlFor="kids">Kids</label>
+            <input name="filter" value="Children" type="radio" onClick={(event) => this.filterBooks(event)} />
           </div>
         </form>
         <ListBox lists={this.state.lists} filteredLists={this.state.filteredLists}/>

--- a/src/Views/Selection/Selection.js
+++ b/src/Views/Selection/Selection.js
@@ -19,6 +19,16 @@ class Selection extends Component {
   render() {
     return (
       <main className="selection">
+        <form className="listFilters">
+          <label for="kids">Kids</label>
+          <input name="kids" type="checkbox" />
+          <label for="youngAdult">Young Adult</label>
+          <input name="youngAdult" type="checkbox" />
+          <label for="fiction">Fiction</label>
+          <input name="fiction" type="checkbox" />
+          <label for="nonFiction">Non-Fiction</label>
+          <input name="nonFiction" type="checkbox" />
+        </form>
         <ListBox list={this.state.list}/>
       </main>
     )


### PR DESCRIPTION
## What does this pull request do?

This PR is for the Selection View (Home page view) and the Preview View.
This PR expands on the file structure, creating multiple new Components/Views.
Functionality is added so that the NYT Bestselling Categories show on initial page load.
When clicking on a Category, a user is also shown a new page - Preview - that lists out the books with minor details on that list.
Lastly, Router links and styling were added for basic functionality of Selection and Preview Views.

### Are there any problems/issues that need to be addressed?

Multiple lists contain no data for "Weeks on Bestseller List" or "Rank Last Week" - consider not showing in that case.
"Back to Home" link on Preview should be button and not have text decoration/coloring.
Icon on Header should link back to Selection (Home).
Radio buttons on Selection should probably be on other side of label.

### Does this close any relevant issues?

n/a

### What's next after this PR is merged?

First another Component is needed to list how many users will be using the app (along with names?)
Then the next View will be started - Approval - where users will vote on their book preferences.
